### PR TITLE
Positioning logo and preventing image from scaling out of proportion

### DIFF
--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -45,12 +45,13 @@ div.row h1,h2,h3,h4,h5 {
   border-bottom: 1px solid #e5e5e5;
 }
 .logo {
+  position: relative;
+  top: 10px;
   width: 80px;
-  height: 71px;
+  height: 80px;
   display: inline-block;
-  margin-bottom: 1em;
   background-image: url("/images/create.png");
-  background-size: 80px 71px;
+  background-size: 80px 80px;
 }
 .page-title {
   font-size: 72px;


### PR DESCRIPTION
Simple change on the roombot image to be centered on text and not skewed.
![screen shot 2016-01-27 at 3 19 01 pm](https://cloud.githubusercontent.com/assets/1081167/12630371/56366b7a-c509-11e5-94a8-e17e41f51da2.png)
